### PR TITLE
fix: fix restart script

### DIFF
--- a/restart.sh
+++ b/restart.sh
@@ -6,7 +6,7 @@ git pull origin main
 pnpm install
 pnpm build
 
-for PID in $(ps -e -o pid,cmd | grep yarn | grep start-vc-notice | awk '{print $1}'); do
+for PID in $(ps -e -o pid,cmd | grep pnpm | grep start-vc-notice | awk '{print $1}'); do
   kill $PID
 done
 

--- a/restart.sh
+++ b/restart.sh
@@ -3,11 +3,11 @@ PATH=$PATH:$HOME/.volta/bin
 git checkout .
 git pull origin main
 
-yarn install
-yarn run build
+pnpm install
+pnpm build
 
 for PID in $(ps -e -o pid,cmd | grep yarn | grep start-vc-notice | awk '{print $1}'); do
   kill $PID
 done
 
-nohup yarn run start-vc-notice &
+nohup pnpm start-vc-notice &


### PR DESCRIPTION
パッケージマネージャーを yarn から pnpm に変更したことに伴い、`restart.sh` を修正