### PR TITLE
fix: return permission error

### DIFF
--- a/src/commands/set/channel.ts
+++ b/src/commands/set/channel.ts
@@ -1,6 +1,10 @@
 import { ChannelType } from "discord.js";
 
-import { setCompletedEmbed, setNotFoundInteractionChannelErrorEmbed } from "../../embed";
+import {
+  setCompletedEmbed,
+  setNotFoundInteractionChannelErrorEmbed,
+  noManageWebhooksPermissionErrorEmbed,
+} from "../../embed";
 import { getGuildData, upsertGuildData } from "../../repositories/guild";
 import { updateWebhook } from "../../services";
 import { buildEmbed, locale2language } from "../../utils";
@@ -14,6 +18,15 @@ export const setChannel = async (client: Client, interaction: CommandInteraction
   if (!guild || !channel || channel.type !== ChannelType.GuildText) {
     await interaction.reply({
       embeds: [buildEmbed(setNotFoundInteractionChannelErrorEmbed(), interaction.locale)],
+      ephemeral: false,
+    });
+
+    return;
+  }
+
+  if (client.user && !channel.permissionsFor(client.user)?.has("ManageWebhooks")) {
+    await interaction.reply({
+      embeds: [buildEmbed(noManageWebhooksPermissionErrorEmbed(), interaction.locale)],
       ephemeral: false,
     });
 

--- a/src/commands/set/language.ts
+++ b/src/commands/set/language.ts
@@ -1,6 +1,10 @@
 import { ChannelType } from "discord.js";
 
-import { setCompletedEmbed, setNotFoundInteractionChannelErrorEmbed } from "../../embed";
+import {
+  setCompletedEmbed,
+  setNotFoundInteractionChannelErrorEmbed,
+  noManageWebhooksPermissionErrorEmbed,
+} from "../../embed";
 import { getGuildData, upsertGuildData } from "../../repositories/guild";
 import { getWebhookChannel, updateWebhook } from "../../services";
 import { buildEmbed, locale2language } from "../../utils";
@@ -15,6 +19,15 @@ export const setLangage = async (client: Client, interaction: CommandInteraction
   if (!guild || !channel || channel.type !== ChannelType.GuildText) {
     await interaction.reply({
       embeds: [buildEmbed(setNotFoundInteractionChannelErrorEmbed(), interaction.locale)],
+      ephemeral: false,
+    });
+
+    return;
+  }
+
+  if (client.user && !channel.permissionsFor(client.user)?.has("ManageWebhooks")) {
+    await interaction.reply({
+      embeds: [buildEmbed(noManageWebhooksPermissionErrorEmbed(), interaction.locale)],
       ephemeral: false,
     });
 

--- a/src/embed/commands/set/errors.ts
+++ b/src/embed/commands/set/errors.ts
@@ -28,3 +28,32 @@ export const setNotFoundInteractionChannelErrorEmbed = (): EmbedContents => ({
     },
   },
 });
+
+export const noManageWebhooksPermissionErrorEmbed = (): EmbedContents => ({
+  en: {
+    title: "An error occurred!",
+    color: "#ff0000",
+    fields: [
+      {
+        name: "Permission required",
+        value: 'You need the "Manage Webhooks" permission in VC Notice',
+      },
+    ],
+    footer: {
+      text: "Please grant permission and try again",
+    },
+  },
+  ja: {
+    title: "エラーが発生しました",
+    color: "#ff0000",
+    fields: [
+      {
+        name: "権限が必要です",
+        value: "VC Notice に「ウェブフックの管理」の権限が必要です",
+      },
+    ],
+    footer: {
+      text: "権限を付与してからもう一度お試しください",
+    },
+  },
+});

--- a/src/embed/commands/set/index.ts
+++ b/src/embed/commands/set/index.ts
@@ -1,5 +1,5 @@
 export * from "./completed";
-export * from "./error";
+export * from "./errors";
 export * from "./help";
 export * from "./bot";
 export * from "./mention";


### PR DESCRIPTION
`/set channel`, `/set language` で権限がなく Webhook を作成できていないのにも関わらず、正常に終了したようにレスポンスを返していたため、権限エラーのレスポンスを返すように修正